### PR TITLE
Fix a segfault caused by an uninitialized field

### DIFF
--- a/hipcl/lib/lzbackend.cc
+++ b/hipcl/lib/lzbackend.cc
@@ -86,6 +86,7 @@ LZDevice::LZDevice(hipDevice_t id, ze_device_handle_t hDevice_, LZDriver* driver
   status = zeDeviceGetCacheProperties(this->hDevice, &count, &(this->deviceCacheProps));
 
   // Query device module properties
+  this->deviceModuleProps.pNext = nullptr;
   status = zeDeviceGetModuleProperties(this->hDevice, &(this->deviceModuleProps));
   
   // Create HipLZ context  


### PR DESCRIPTION
Fix a segmentation fault caused by an uninitialized pointer field
'pNext' in the ze_device_module_properties_t struct.
zeDeviceGetModuleProperties() reads this (optional) field.