### PR TITLE
Fix maxGridSizes were reported negative

### DIFF
--- a/hipcl/CMakeLists.txt
+++ b/hipcl/CMakeLists.txt
@@ -193,3 +193,4 @@ install(FILES
 ##########################################
 
 add_subdirectory(samples)
+add_subdirectory(tests)

--- a/hipcl/lib/lzbackend.cc
+++ b/hipcl/lib/lzbackend.cc
@@ -188,9 +188,17 @@ void LZDevice::setupProperties(int index) {
     this->deviceComputeProps.subGroupSizes[this->deviceComputeProps.numSubGroupSizes-1];
 
   // Replicate from OpenCL implementation
-  Properties.maxGridSize[0] = this->deviceComputeProps.maxGroupCountX;
-  Properties.maxGridSize[1] = this->deviceComputeProps.maxGroupCountY;
-  Properties.maxGridSize[2] = this->deviceComputeProps.maxGroupCountZ;
+
+  // HIP and level zero API uses int and uint32_t type, respectively,
+  // for storing the group count. Clamp the group count to INT_MAX to
+  // avoid 2^31+ size being interpreted as negative number.
+  constexpr unsigned int_max = std::numeric_limits<int>::max();
+  Properties.maxGridSize[0] =
+      std::min(this->deviceComputeProps.maxGroupCountX, int_max);
+  Properties.maxGridSize[1] =
+      std::min(this->deviceComputeProps.maxGroupCountY, int_max);
+  Properties.maxGridSize[2] =
+      std::min(this->deviceComputeProps.maxGroupCountZ, int_max);
   Properties.memoryClockRate = this->deviceMemoryProps.maxClockRate;
   Properties.memoryBusWidth = this->deviceMemoryProps.maxBusWidth;
   Properties.major = 2;

--- a/hipcl/tests/CMakeLists.txt
+++ b/hipcl/tests/CMakeLists.txt
@@ -1,0 +1,58 @@
+
+option(SAVE_TEMPS "Save temporary compilation products" OFF)
+option(VERBOSE "Verbose compilation" OFF)
+
+if(SAVE_TEMPS)
+  add_compile_options("--save-temps")
+endif()
+
+if(VERBOSE)
+  add_compile_options("-v")
+endif()
+
+# ARGN = test args
+function(add_hipcl_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
+
+    set(TEST_EXEC_ARGS ${ARGN})
+    set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CXX)
+
+    add_executable("${EXEC_NAME}" ${SOURCE})
+
+    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+
+    target_link_libraries("${EXEC_NAME}" "${SANITIZER_LIBS}" "hipcl" "OpenCL"
+                          "ze_loader")
+
+    install(TARGETS "${EXEC_NAME}"
+            RUNTIME DESTINATION "${HIPCL_SAMPLE_BINDIR}")
+
+    add_test(NAME "${TEST_NAME}"
+             COMMAND "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}"
+                     ${TEST_EXEC_ARGS})
+
+    set_tests_properties("${TEST_NAME}" PROPERTIES
+                         PASS_REGULAR_EXPRESSION "${TEST_PASS}")
+
+
+endfunction()
+
+# ARGN = sources
+function(add_hipcl_binary EXEC_NAME)
+
+    set(SOURCES ${ARGN})
+    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
+
+    add_executable("${EXEC_NAME}" ${SOURCES})
+
+    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+
+    target_link_libraries("${EXEC_NAME}" "${SANITIZER_LIBS}" "hipcl" "OpenCL"
+                          "ze_loader")
+
+    install(TARGETS "${EXEC_NAME}"
+            RUNTIME DESTINATION "${HIPCL_SAMPLE_BINDIR}")
+
+endfunction()
+
+add_hipcl_test(regression-maxgridsize regression-maxgridsize
+               PASSED regression-maxgridsize.cc)

--- a/hipcl/tests/regression-maxgridsize.cc
+++ b/hipcl/tests/regression-maxgridsize.cc
@@ -1,0 +1,22 @@
+// Check maxGridSize properties are positive.
+#include "hip/hip_runtime.h"
+#include <iostream>
+
+int main() {
+  hipDeviceProp_t deviceProps;
+  auto error = hipGetDeviceProperties(&deviceProps, 0);
+  if (error != hipSuccess) {
+    std::cout << "HIP ERROR: '" << hipGetErrorString(error) << "'\n";
+    return 1;
+  }
+  for (int i = 0; i < 3; i++) {
+    auto size = deviceProps.maxGridSize[i];
+    if (size < 0) {
+      std::cout << "FAIL: maxGridSize[" << i << "] is negative (" << size
+                << ")!\n";
+      return 2;
+    }
+  }
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
* Fix maxGridSizes values from hipGetDeviceProperties() were reported negative. More details in the commit log.

* Add a dedicated test directory and a regression test for this issue.
