### PR TITLE
adding hip+MKL version with no buffers

### DIFF
--- a/hipcl/samples/hip_sycl_interop_no_buffers/build.sh
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+module use /home/jyoung/gpfs_share/compilers/modulefiles/oneapi/2020.2.0.2997/
+#module avail
+module load mkl compiler
+module load intel_compute_runtime/release/latest
+
+dpcpp onemkl_gemm_wrapper.cpp -DMKL_ILP64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -o libonemkl_gemm_wrapper.so -fsycl -lze_loader -shared -fPIC
+
+module use /home/bertoni/modulefiles
+module load hiplz/wip
+rm ./a.out
+clang++ -std=c++11 hiplz_sycl_interop.cpp -lhiplz -lOpenCL -lze_loader -lonemkl_gemm_wrapper -L.
+
+
+export LD_LIBRARY_PATH=/home/bertoni/projects/p051.hiplz_mkl/:$LD_LIBRARY_PATH
+./a.out

--- a/hipcl/samples/hip_sycl_interop_no_buffers/hiplz_sycl_interop.cpp
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/hiplz_sycl_interop.cpp
@@ -1,0 +1,107 @@
+#include "hip/hip_runtime.h"
+
+// STL classes
+#include <exception>
+#include <iostream>
+
+#include <vector>
+
+#include "hiplz_sycl_interop.h"
+
+using namespace std;
+
+const int WIDTH = 10;
+
+bool ValueSame(double a, double b) {
+  return std::fabs(a-b) < 1.0e-08;  
+}
+
+void VerifyResult(double *c_A, double *c_B) {
+  bool MismatchFound = false;
+
+  for (size_t i=0; i < WIDTH; i++) {
+    for (size_t j=0; j < WIDTH; j++) {
+      if (!ValueSame(c_A[i*WIDTH+j], c_B[i*WIDTH+j])) {
+	std::cout << "fail - The result is incorrect for element: [" << i << ", " << j
+		  << "], expected: " << c_A[i*WIDTH+j] << " , but got: " << c_B[i*WIDTH+j]
+		  << std::endl;
+	//	exit(1);
+        MismatchFound = true;
+      }
+    }
+  }
+
+  if (!MismatchFound) {
+    std::cout << "SUCCESS - The results are correct!" << std::endl;
+    return;
+  }
+
+}
+
+int main() { 
+  double * A = (double *) malloc(WIDTH*WIDTH*sizeof(double));
+  double * B = (double *) malloc(WIDTH*WIDTH*sizeof(double));
+  double * C = (double *) malloc(WIDTH*WIDTH*sizeof(double));
+  double * C_serial = (double *) malloc(WIDTH*WIDTH*sizeof(double));
+
+  double *d_A, *d_B, *d_C;
+  // matrix data sizes
+  int m = WIDTH;
+  int n = WIDTH;
+  int k = WIDTH;
+  int ldA, ldB, ldC;
+  ldA = ldB = ldC = WIDTH;
+  double alpha = 1.0;
+  double beta  = 0.0;
+  
+  // Create HipLZ stream  
+  hipStream_t stream = nullptr;
+  hipStreamCreate(&stream);
+
+  unsigned long nativeHandlers[4];
+  int numItems = 0;
+  hipStreamNativeInfo(stream, nativeHandlers, &numItems);
+
+  // allocate memory
+  hipMalloc( &d_A, WIDTH*WIDTH*sizeof(double));
+  hipMalloc( &d_B, WIDTH*WIDTH*sizeof(double));
+  hipMalloc( &d_C, WIDTH*WIDTH*sizeof(double));
+
+  // initialize data on the host
+    // prepare matrix data with ROW-major style
+  // A(M, N)
+  for (size_t i=0; i<WIDTH; i++)
+    for (size_t j=0; j<WIDTH; j++)
+      A[i*WIDTH + j] = i*WIDTH + j;
+  // B(N, P)
+  for (size_t i=0; i<WIDTH; i++)
+    for (size_t j=0; j<WIDTH; j++)
+      B[i*WIDTH + j] = i*WIDTH + j;
+
+  // get CPU result
+  // Resultant matrix: C_serial = A*B
+  for (size_t i=0; i<WIDTH; i++) {
+    for (size_t j=0; j<WIDTH; j++) {
+      C_serial[i*WIDTH + j] = 0;
+      for(size_t d=0; d<WIDTH; d++) {
+	C_serial[i*WIDTH + j] += A[i*WIDTH + d] * B[d*WIDTH + j];
+      }
+    }
+  }
+
+  // copy A and B to the device
+  hipMemcpy(d_A, A, WIDTH*WIDTH*sizeof(double), hipMemcpyHostToDevice);
+  hipMemcpy(d_B, B, WIDTH*WIDTH*sizeof(double), hipMemcpyHostToDevice);
+  
+  // Invoke oneMKL GEMM
+  oneMKLGemmTest(nativeHandlers, d_A, d_B, d_C, WIDTH, WIDTH, WIDTH, ldA, ldB, ldC, alpha, beta);
+
+  // copy back C
+  hipMemcpy(C, d_C, WIDTH*WIDTH*sizeof(double), hipMemcpyDeviceToHost);
+    
+  // check results
+  std::cout << "Verify results between OneMKL & Serial: ";  
+  VerifyResult(C, C_serial);
+
+  return 0;
+}

--- a/hipcl/samples/hip_sycl_interop_no_buffers/hiplz_sycl_interop.h
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/hiplz_sycl_interop.h
@@ -1,0 +1,10 @@
+#ifndef __HIPLZ_SYCL_INTEROP_H__
+#define __HIPLZ_SYCL_INTEROP_H__
+
+extern "C" {
+  // Run GEMM test via oneMKL
+  int oneMKLGemmTest(unsigned long* nativeHandlers, double* A, double* B, double* C, int M, int N, int K,
+		     int ldA, int ldB, int ldC, double alpha, double beta);
+}
+
+#endif

--- a/hipcl/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper.cpp
@@ -1,0 +1,76 @@
+#include "level_zero/ze_api.h"
+#include "CL/sycl/backend/level_zero.hpp"
+#include "oneapi/mkl.hpp"
+#include <stdlib.h>
+#include <vector>
+#include <string.h>
+#include <stdio.h>
+
+#include "hiplz_sycl_interop.h"
+
+using namespace std;
+
+int onemkl_gemm(sycl::queue& my_queue, double* A, double* B, double* C, int m, int n, int k,
+		int ldA, int ldB, int ldC, double alpha, double beta) {
+  
+  auto my_exception_handler = [](sycl::exception_list exceptions) {
+    for (std::exception_ptr const& e : exceptions) {
+      try {
+        std::rethrow_exception(e);
+      }
+      catch (sycl::exception const& e) {
+        std::cout << "Caught asynchronous SYCL exception:\n"
+        << e.what() << std::endl;
+      }
+      catch (std::exception const& e) {
+        std::cout << "Caught asynchronous STL exception:\n"
+        << e.what() << std::endl;
+      }
+    }
+  };
+   
+  // create sycl buffers of matrix data for offloading between device and host 
+  // add oneapi::mkl::blas::gemm to execution queue and catch any synchronous exceptions  
+  try {
+    oneapi::mkl::blas::gemm(my_queue,
+			    oneapi::mkl::transpose::nontrans,
+			    oneapi::mkl::transpose::nontrans,
+			    m, n, k, alpha,
+			    A, ldA, B, ldB, beta, C, ldC);
+  } catch (sycl::exception const& e) {
+    std::cout << "\t\tCaught synchronous SYCL exception during GEMM:\n"
+              << e.what() << std::endl;
+  } catch (std::exception const& e) {
+    std::cout << "\t\tCaught synchronous STL exception during GEMM:\n"
+              << e.what() << std::endl;
+  }
+  
+  // ensure any asynchronous exceptions caught are handled before proceeding 
+  my_queue.wait_and_throw();
+
+  printf( "Here!\n");
+  
+  return 0;
+}
+
+// Run GEMM test via oneMKL  
+int oneMKLGemmTest(unsigned long* nativeHandlers, double* A, double* B, double* C, int M, int N, int K,
+                     int ldA, int ldB, int ldC, double alpha, double beta) {
+  // Extract the native information
+  ze_driver_handle_t        hDriver  = (ze_driver_handle_t)nativeHandlers[0];
+  ze_device_handle_t        hDevice  = (ze_device_handle_t)nativeHandlers[1];
+  ze_context_handle_t       hContext = (ze_context_handle_t)nativeHandlers[2];
+  ze_command_queue_handle_t hQueue   = (ze_command_queue_handle_t)nativeHandlers[3];
+    
+  sycl::platform sycl_platform = sycl::level_zero::make<sycl::platform>(hDriver);
+ 
+  // make devices from converted platform and L0 device 
+  sycl::device sycl_device = sycl::level_zero::make<sycl::device>(sycl_platform, hDevice);
+  std::vector<sycl::device> devices;
+  devices.push_back(sycl_device);
+  sycl::context sycl_context = sycl::level_zero::make<sycl::context>(devices, hContext);
+  sycl::queue queue = sycl::level_zero::make<sycl::queue>(sycl_context, hQueue);
+
+  // Test the oneMKL  
+  return onemkl_gemm(queue, A, B, C, M, N, K, ldA, ldB, ldC, alpha, beta);
+}


### PR DESCRIPTION
This is adding a new example where the memory allocation is done with HIP and passed to MKL.

I didn't use the same stream for memory allocation, though. Will try to adjust later if we want to keep the example.