### PR TITLE
Changes to fix home-directory based tools after JLSE migration

### DIFF
--- a/hipcl/samples/hip_sycl_interop/build.sh
+++ b/hipcl/samples/hip_sycl_interop/build.sh
@@ -1,5 +1,8 @@
 # Pre-requiremnt
 # Setup Intel runtime:  
+
+#set -x
+
 module use /soft/modulefiles/
 module load intel_compute_runtime cmake
 
@@ -10,19 +13,24 @@ module load intel_compute_runtime cmake
 # The ONEAPI_COMPILER_PREFIX is the intallation of DPC++, e.g. ~/intel/oneapi/compiler/latest/linux
 #
 # Or using DPC++ on JLSE:   
-module use /home/jyoung/gpfs_share/compilers/modulefiles/oneapi/2020.2.0.2997/
+
+#Set temp pointer to user-specific directories
+HOME_JZ=/home/ac.jzhao1
+SHARE_JY=/home/ac.jyoung/gpfs_share
+
+module use ${SHARE_JY}/compilers/modulefiles/oneapi/2021.3.0/
 module load mkl compiler
 
 # Set the HIPLZ_INSTALL_PREFIX as HipLZ installation since the dynamic shared library that encapsulates HIP matrix muplication was pre-built and installed at ${HIPLZ_INSTALL_PREFIX}/lib
-export HIPLZ_INSTALL_PREFIX=/home/jzhao/hipclworkspace/hipcl/install/
+export HIPLZ_INSTALL_PREFIX=${HOME_JZ}/hipclworkspace/hipcl/install/
 
 clang++ onemkl_gemm_wrapper.cpp -DMKL_ILP64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -o libonemkl_gemm_wrapper.so -fsycl -lze_loader -shared -fPIC
 
 # Build the HIPLZ part for invoking SyCL based library
 # Setup the environment based on JLSE
 export HIPCL_CLANG_PREFIX=/soft/compilers/clang-hipcl/8.0-20210506
-export HIPLZ_BUILD=/home/jzhao/hipclworkspace/hipcl/build
-export HIPLZ_INCLUDE=/home/jzhao/hipclworkspace/hipcl/include
+export HIPLZ_BUILD=${HOME_JZ}/hipclworkspace/hipcl/build
+export HIPLZ_INCLUDE=${HOME_JZ}/hipclworkspace/hipcl/include
 
 export OPENCL_INSTALLATION=/soft/libraries/pocl/OpenCL-ICD-Loader/build-v2020.06.16
 
@@ -35,4 +43,5 @@ ${HIPCL_CLANG_PREFIX}/bin/clang++ -I${HIPLZ_INCLUDE} -g -fPIE -x hip --hip-devic
 ${HIPCL_CLANG_PREFIX}/bin/clang++ -g hiplz_sycl_interop.o -o hiplz_sycl_interop.exe -Wl,-rpath,${HIPLZ_INSTALL_PREFIX}/lib:${OPENCL_INSTALLATION}: ${HIPLZ_INSTALL_PREFIX}lib/libhiplz.so.0.9.0 libonemkl_gemm_wrapper.so -lOpenCL -lze_loader -pthread ${OPENCL_INSTALLATION}/libOpenCL.so.1.2
 
 # run test
+echo "Running the HIPLZ SYCL example:"
 ./hiplz_sycl_interop.exe

--- a/hipcl/samples/hip_sycl_interop_no_buffers/build.sh
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/build.sh
@@ -10,17 +10,24 @@ module load intel_compute_runtime cmake
 # The ONEAPI_COMPILER_PREFIX is the intallation of DPC++, e.g. ~/intel/oneapi/compiler/latest/linux
 #
 # Or using DPC++ on JLSE:   
-module use /home/jyoung/gpfs_share/compilers/modulefiles/oneapi/2020.2.0.2997/
+
+#Set temp pointer to user-specific directories
+HOME_JZ=/home/ac.jzhao1
+SHARE_JY=/home/ac.jyoung/gpfs_share
+
+module use ${SHARE_JY}/compilers/modulefiles/oneapi/2021.3.0/
 module load mkl compiler
 
 # Set the HIPLZ_INSTALL_PREFIX as HipLZ installation since the dynamic shared library that encapsulates HIP matrix muplication was pre-built and installed at ${HIPLZ_INSTALL_PREFIX}/lib
+export HIPLZ_INSTALL_PREFIX=${HOME_JZ}/hipclworkspace/hipcl/install/
+
 clang++ onemkl_gemm_wrapper.cpp -DMKL_ILP64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -o libonemkl_gemm_wrapper.so -fsycl -lze_loader -shared -fPIC
 
 # Build the HIPLZ part for invoking SyCL based library
 # Setup the environment based on JLSE
 export HIPCL_CLANG_PREFIX=/soft/compilers/clang-hipcl/8.0-20210506
-export HIPLZ_BUILD=/home/jzhao/hipclworkspace/hipcl/build
-export HIPLZ_INCLUDE=/home/jzhao/hipclworkspace/hipcl/include
+export HIPLZ_BUILD=${HOME_JZ}/hipclworkspace/hipcl/build
+export HIPLZ_INCLUDE=${HOME_JZ}/hipclworkspace/hipcl/include
 
 export OPENCL_INSTALLATION=/soft/libraries/pocl/OpenCL-ICD-Loader/build-v2020.06.16
 
@@ -33,4 +40,5 @@ ${HIPCL_CLANG_PREFIX}/bin/clang++ -I${HIPLZ_INCLUDE} -g -fPIE -x hip --hip-devic
 ${HIPCL_CLANG_PREFIX}/bin/clang++ -g hiplz_sycl_interop.o -o hiplz_sycl_interop.exe -Wl,-rpath,${HIPLZ_INSTALL_PREFIX}/lib:${OPENCL_INSTALLATION}: ${HIPLZ_INSTALL_PREFIX}lib/libhiplz.so.0.9.0 libonemkl_gemm_wrapper.so -lOpenCL -lze_loader -pthread ${OPENCL_INSTALLATION}/libOpenCL.so.1.2
 
 # run test
+echo "Running the HIPLZ SYCL nobuffer example:"
 ./hiplz_sycl_interop.exe

--- a/hipcl/samples/hip_sycl_interop_no_buffers/build_with_module.sh
+++ b/hipcl/samples/hip_sycl_interop_no_buffers/build_with_module.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-module use /home/jyoung/gpfs_share/compilers/modulefiles/oneapi/2020.2.0.2997/
+module use /home/ac.jyoung/gpfs_share/compilers/modulefiles/oneapi/2021.3.0/
 #module avail
 module load mkl compiler
 module load intel_compute_runtime/release/latest
@@ -9,9 +9,8 @@ dpcpp onemkl_gemm_wrapper.cpp -DMKL_ILP64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_seq
 
 module use /home/bertoni/modulefiles
 module load hiplz/wip
-rm ./a.out
+rm -f ./a.out
 clang++ -std=c++11 hiplz_sycl_interop.cpp -lhiplz -lOpenCL -lze_loader -lonemkl_gemm_wrapper -L.
-
 
 export LD_LIBRARY_PATH=/home/bertoni/projects/p051.hiplz_mkl/:$LD_LIBRARY_PATH
 ./a.out

--- a/hipcl/samples/sycl_hip_interop/build.sh
+++ b/hipcl/samples/sycl_hip_interop/build.sh
@@ -9,10 +9,13 @@ module load intel_compute_runtime cmake
 # The ONEAPI_COMPILER_PREFIX is the intallation of DPC++, e.g. ~/intel/oneapi/compiler/latest/linux
 #
 # Or using DPC++ on JLSE:
-module use /home/jyoung/gpfs_share/compilers/modulefiles/oneapi/2020.2.0.2997/
+SHARE_JY=/home/ac.jyoung/gpfs_share
+module use ${SHARE_JY}/compilers/modulefiles/oneapi/2021.3.0/
 module load mkl compiler
 
 # Set the HIPLZ_INSTALL_PREFIX as HipLZ installation since the dynamic shared library that encapsulates HIP matrix muplication was pre-built and installed at ${HIPLZ_INSTALL_PREFIX}/lib
+HOME_JZ=/home/ac.jzhao1
+export HIPLZ_INSTALL_PREFIX=${HOME_JZ}/hipclworkspace/hipcl/install/
 clang++ sycl_hiplz_interop.cpp -o sycl_hiplz_interop.exe -fsycl  -lze_loader -L${HIPLZ_INSTALL_PREFIX}/lib -lSyCL2HipLZMM -lhiplz
 
 # Run the built test


### PR DESCRIPTION
This PR updates some of the tool paths to fix an issue we saw with the `sycl_hip_interop` example. 